### PR TITLE
Replace `@change` for `initComplete`

### DIFF
--- a/src/components/DataTable4.vue
+++ b/src/components/DataTable4.vue
@@ -5,7 +5,6 @@
       class="display cell-border"
       width="100%"
       :options="options"
-      @change="addButtEvList"
     />
 </template>
 
@@ -25,7 +24,14 @@ export default {
         responsive: true,
         autoWidth: false,
         destroy: true,
-        deferRender: true
+        deferRender: true,
+        initComplete: function () {
+        this.on('page.dt', function () {
+          nextTick(() => {
+            addButtEvList();
+          });
+        });
+      },
       },
       columns: [
         { data: 'id', title: 'ID', width: '10%' },


### PR DESCRIPTION
For some reason  `@change="addButtEvList"` isn't working. I've replaced that call with
`initComplete: function () {
        this.on('page.dt', function () {
          nextTick(() => {
            addButtEvList();
          });
        });
      },`
in options, will work the same as it was intended